### PR TITLE
Remove deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,15 @@
 'use strict';
 
 var es = require('event-stream');
-var gutil = require('gulp-util');
 var extend = require('lodash.assign');
+var template = require('./template');
 
 var footerPlugin = function(footerText, data) {
   footerText = footerText || '';
   return es.map(function(file, cb){
     file.contents = Buffer.concat([
       file.contents,
-      new Buffer(gutil.template(footerText, extend({file : file}, data)))
+      new Buffer(template(footerText, extend({file : file}, data)))
     ]);
     cb(null, file);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,49 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -64,32 +26,17 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
-    },
     "clone": {
       "version": "1.0.3",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-    },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
@@ -102,16 +49,6 @@
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "dateformat": {
-      "version": "2.2.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
     "debug": {
       "version": "3.1.0",
@@ -133,18 +70,11 @@
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "requires": {
-        "readable-stream": "1.1.14"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "event-stream": {
       "version": "3.3.4",
@@ -158,16 +88,6 @@
         "split": "0.3.3",
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
-      }
-    },
-    "fancy-log": {
-      "version": "1.3.2",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/fancy-log/-/fancy-log-1.3.2.tgz",
-      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-      "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "time-stamp": "1.1.0"
       }
     },
     "from": {
@@ -195,74 +115,17 @@
         "path-is-absolute": "1.0.1"
       }
     },
-    "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
-    "gulp-util": {
-      "version": "3.0.8",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/gulp-util/-/gulp-util-3.0.8.tgz",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "2.2.0",
-        "fancy-log": "1.3.2",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "requires": {
-        "glogg": "1.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "requires": {
-        "sparkles": "1.0.0"
-      }
     },
     "he": {
       "version": "1.1.1",
@@ -283,12 +146,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -412,11 +271,6 @@
         "brace-expansion": "1.1.8"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -469,19 +323,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
-    },
-    "object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/once/-/once-1.4.0.tgz",
@@ -505,31 +346,11 @@
         "through": "2.3.8"
       }
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
-    },
     "replace-ext": {
       "version": "0.0.1",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
     },
     "should": {
       "version": "13.2.0",
@@ -585,11 +406,6 @@
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
       "dev": true
     },
-    "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
-    },
     "split": {
       "version": "0.3.3",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/split/-/split-0.3.3.tgz",
@@ -606,81 +422,16 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true,
       "requires": {
         "clone": "1.0.3",
         "clone-stats": "0.0.1",
@@ -692,11 +443,6 @@
       "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,702 @@
+{
+  "name": "gulp-footer",
+  "version": "1.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "requires": {
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "1.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
+    "object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "should": {
+      "version": "13.2.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should/-/should-13.2.0.tgz",
+      "integrity": "sha512-DWrmYTHzvfaIRZhgVqEjGwzuYgowiiFxsvRViNv2HviAlRofWvGnkaDITLu6omAq5cBjZ9dk/Sn4tI06vE/+iw==",
+      "dev": true,
+      "requires": {
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "requires": {
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://connectionseducation.pkgs.visualstudio.com/_packaging/ConnectionsEducationNpm/npm/registry/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,11 +42,14 @@
   },
   "dependencies": {
     "event-stream": "*",
-    "gulp-util": "*",
-    "lodash.assign": "*"
+    "lodash._reescape": "^3.0.0",
+    "lodash._reevaluate": "^3.0.0",
+    "lodash.assign": "*",
+    "lodash.template": "^3.6.2"
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "vinyl": "^0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "eventstream"
   ],
   "author": {
-      "name": "Michael J. Ryan",
-      "email": "mxryan@godaddy.com",
-      "url": "http://github.com/tracker1"
+    "name": "Michael J. Ryan",
+    "email": "mxryan@godaddy.com",
+    "url": "http://github.com/tracker1"
   },
   "contributors": [
     {

--- a/template.js
+++ b/template.js
@@ -1,0 +1,23 @@
+var template = require('lodash.template');
+var reEscape = require('lodash._reescape');
+var reEvaluate = require('lodash._reevaluate');
+var reInterpolate = require('lodash._reinterpolate');
+
+var forcedSettings = {
+  escape: reEscape,
+  evaluate: reEvaluate,
+  interpolate: reInterpolate
+};
+
+module.exports = function(tmpl, data) {
+  var fn = template(tmpl, forcedSettings);
+
+  var wrapped = function(o) {
+    if (typeof o === 'undefined' || typeof o.file === 'undefined') {
+      throw new Error('Failed to provide the current file as "file" to the template');
+    }
+    return fn(o);
+  };
+
+  return (data ? wrapped(data) : wrapped);
+};

--- a/template.js
+++ b/template.js
@@ -1,3 +1,5 @@
+//The following content is a 1-1 copy of gulp-util@3.0.8/lib/template.js to preserve full compatibility after the removal of gulp-util.
+
 var template = require('lodash.template');
 var reEscape = require('lodash._reescape');
 var reEvaluate = require('lodash._reevaluate');

--- a/test/main.js
+++ b/test/main.js
@@ -4,14 +4,14 @@
 
 var footer = require('../');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 require('mocha');
 
 describe('gulp-footer', function() {
   var fakeFile;
 
   function getFakeFile(fileContent){
-    return new gutil.File({
+    return new Vinyl({
       path: './test/fixture/file.js',
       cwd: './test/',
       base: './test/fixture/',


### PR DESCRIPTION
Resolves #4 

Rather than picking the latest available versions, I chose a safe upgrade path by using the same versions the previously-referenced _gulp-util@3.0.8_ used. I also brought in the existing _template.js_ from _gulp-util_ and annotated it with a comment. `npm test` passed for everything.

This PR could either be merged in to preserve the status quote after _gulp-util_ is removed, followed by a subsequent PR to update versions, if desired, or the PR could be improved to also update the versions right away. I defer this decision to @tracker1.