### PR TITLE
Updating package.json to include the required dependency for 'lodash.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "event-stream": "*",
     "lodash._reescape": "^3.0.0",
     "lodash._reevaluate": "^3.0.0",
+    "lodash._reinterpolate": "^3.0.0",
     "lodash.template": "^3.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The required dependency for 'lodash._reinterpolate' in template.js is causing builds to fail. I simply added it to the package.json file. 