### PR TITLE
security: pin event-stream to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/tracker1/gulp-footer/issues"
   },
   "dependencies": {
-    "event-stream": "*",
+    "event-stream": "3.3.4",
     "lodash._reescape": "^3.0.0",
     "lodash._reevaluate": "^3.0.0",
     "lodash._reinterpolate": "^3.0.0",


### PR DESCRIPTION
This closes #11.

See https://github.com/dominictarr/event-stream/issues/116